### PR TITLE
fix: address reliability and validation bugs (#9, #11, #17, #12)

### DIFF
--- a/src/specinit/cli/main.py
+++ b/src/specinit/cli/main.py
@@ -15,6 +15,22 @@ from specinit.storage.history import HistoryManager
 console = Console()
 
 
+def validate_port(_ctx: click.Context, _param: click.Parameter, value: int) -> int:
+    """Validate port is in valid range (1024-65535).
+
+    Issue #12 Fix: Validate port number to avoid confusing runtime errors.
+    Rejects privileged ports (< 1024) that require elevated permissions
+    and invalid ports (> 65535).
+    """
+    if value < 1024:
+        raise click.BadParameter(
+            f"Port {value} requires elevated permissions. Use a port between 1024 and 65535."
+        )
+    if value > 65535:
+        raise click.BadParameter(f"Port {value} is invalid. Use a port between 1024 and 65535.")
+    return value
+
+
 @click.group()
 @click.version_option(version=__version__, prog_name="specinit")
 def cli() -> None:
@@ -66,7 +82,8 @@ def init(api_key: str) -> None:
 @click.option(
     "--port",
     default=8765,
-    help="Port for the local web server.",
+    callback=validate_port,
+    help="Port for the local web server (1024-65535).",
 )
 @click.option(
     "--no-browser",

--- a/tests/unit/test_github_service.py
+++ b/tests/unit/test_github_service.py
@@ -1,0 +1,140 @@
+"""Tests for GitHub service."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from specinit.github.service import GitHubService
+
+
+class TestGitHubServiceSession:
+    """Tests for GitHubService session management (Issue #9 fix)."""
+
+    def test_close_closes_session(self):
+        """close() should close the underlying requests session."""
+        with patch("specinit.github.service.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+
+            service = GitHubService(token="test-token")
+            service.close()
+
+            mock_session.close.assert_called_once()
+
+    def test_context_manager_closes_session_on_exit(self):
+        """Using as context manager should close session on exit."""
+        with patch("specinit.github.service.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+
+            with GitHubService(token="test-token") as service:
+                assert service is not None
+
+            mock_session.close.assert_called_once()
+
+    def test_context_manager_closes_session_on_exception(self):
+        """Context manager should close session even when exception occurs."""
+        with patch("specinit.github.service.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_session_cls.return_value = mock_session
+
+            with pytest.raises(ValueError), GitHubService(token="test-token"):
+                raise ValueError("Test error")
+
+            mock_session.close.assert_called_once()
+
+    def test_context_manager_returns_self(self):
+        """Context manager __enter__ should return self."""
+        with patch("specinit.github.service.requests.Session"):
+            service = GitHubService(token="test-token")
+            result = service.__enter__()
+            assert result is service
+            service.close()
+
+
+class TestMergePullRequest:
+    """Tests for merge_pull_request error handling (Issue #17 fix)."""
+
+    def test_merge_success_returns_true(self):
+        """Successful merge should return True."""
+        with patch("specinit.github.service.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_session.put.return_value = mock_response
+            mock_session_cls.return_value = mock_session
+
+            service = GitHubService(token="test-token")
+            result = service.merge_pull_request("owner", "repo", 1)
+
+            assert result is True
+
+    def test_merge_not_allowed_raises_value_error(self):
+        """405 status should raise ValueError with message."""
+        with patch("specinit.github.service.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 405
+            mock_response.json.return_value = {"message": "Pull Request is not mergeable"}
+            mock_session.put.return_value = mock_response
+            mock_session_cls.return_value = mock_session
+
+            service = GitHubService(token="test-token")
+
+            with pytest.raises(ValueError, match="cannot be merged"):
+                service.merge_pull_request("owner", "repo", 1)
+
+    def test_merge_conflict_raises_value_error(self):
+        """409 status should raise ValueError about merge conflicts."""
+        with patch("specinit.github.service.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 409
+            mock_session.put.return_value = mock_response
+            mock_session_cls.return_value = mock_session
+
+            service = GitHubService(token="test-token")
+
+            with pytest.raises(ValueError, match="merge conflicts"):
+                service.merge_pull_request("owner", "repo", 1)
+
+    def test_merge_other_error_raises_runtime_error(self):
+        """Other error status should raise RuntimeError."""
+        with patch("specinit.github.service.requests.Session") as mock_session_cls:
+            mock_session = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 500
+            mock_session.put.return_value = mock_response
+            mock_session_cls.return_value = mock_session
+
+            service = GitHubService(token="test-token")
+
+            with pytest.raises(RuntimeError, match="status 500"):
+                service.merge_pull_request("owner", "repo", 1)
+
+
+class TestParseRepoUrl:
+    """Tests for parse_repo_url."""
+
+    def test_parse_https_url(self):
+        """Should parse HTTPS GitHub URLs."""
+        owner, repo = GitHubService.parse_repo_url("https://github.com/owner/repo")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_parse_ssh_url(self):
+        """Should parse SSH GitHub URLs."""
+        owner, repo = GitHubService.parse_repo_url("git@github.com:owner/repo.git")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_parse_owner_repo_format(self):
+        """Should parse owner/repo format."""
+        owner, repo = GitHubService.parse_repo_url("owner/repo")
+        assert owner == "owner"
+        assert repo == "repo"
+
+    def test_invalid_url_raises(self):
+        """Should raise ValueError for invalid URLs."""
+        with pytest.raises(ValueError, match="Invalid GitHub URL"):
+            GitHubService.parse_repo_url("not-a-valid-url")


### PR DESCRIPTION
## Summary

This PR fixes four bugs related to reliability and input validation:

1. **Issue #9**: Resource leak in GitHubService
   - requests.Session was never closed, causing connection pool leaks
   - Added close() and context manager support

2. **Issue #11**: Unhandled JSON parse error in WebSocket
   - Malformed JSON crashed the WebSocket connection
   - Now returns graceful error messages

3. **Issue #17**: Unchecked merge PR return value
   - merge_pull_request returned boolean without distinguishing error types
   - Now raises specific exceptions with meaningful messages

4. **Issue #12**: Missing port validation in CLI
   - Invalid ports caused confusing runtime errors
   - Now validates port range (1024-65535) with clear messages

## Changes

### GitHubService (Issue #9)
- Added `close()` method to release session resources
- Implemented `__enter__` and `__exit__` for context manager protocol
- Enables pattern: `with GitHubService() as github:`

### WebSocket Endpoint (Issue #11)
- Added try-except for `json.JSONDecodeError`
- Added try-except for pydantic `ValidationError`
- Returns `{"type": "error", "message": "..."}` instead of crashing

### merge_pull_request (Issue #17)
- Returns `True` on success (200)
- Raises `ValueError` for 405 (PR not mergeable) with reason
- Raises `ValueError` for 409 (merge conflicts)
- Raises `RuntimeError` for other API errors

### CLI Port Validation (Issue #12)
- Added `validate_port` callback for `--port` option
- Rejects ports < 1024 (privileged, require sudo)
- Rejects ports > 65535 (invalid)

## Test plan

- [x] All 210 tests passing
- [x] Coverage at 90.79% (above 90% threshold)
- [x] All lint checks pass (ruff, mypy, eslint)
- [x] Pre-commit hooks pass
- [ ] CI passes
- [ ] Code review approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)