### PR TITLE
fix: add web dependencies guidance for Expo projects (#30)

### DIFF
--- a/src/specinit/generator/prompts.py
+++ b/src/specinit/generator/prompts.py
@@ -283,6 +283,15 @@ select = [
   - Use `npx expo install <package>` to ensure version compatibility
   - Avoid manually specifying versions that conflict with Expo SDK
 
+### For Expo projects with web support:
+- CRITICAL: Include web-specific dependencies when "web" is a target platform:
+  - react-dom: 18.3.1 (required for web rendering)
+  - react-native-web: ~0.19.12 (bridges React Native to web)
+  - @expo/metro-runtime: ~4.0.0 (Expo web runtime)
+- Configure app.json to include "web" in platforms array
+- Ensure metro.config.js supports web platform
+- Note: Web support requires additional setup compared to native platforms
+
 ### .pre-commit-config.yaml
 - Use LOCAL hooks (not external repos) to ensure same versions as CI
 - Run via `python -m <tool>` for consistency


### PR DESCRIPTION
## Problem

Expo projects that include "web" as a target platform are missing required web dependencies, causing the error:
```
It looks like you're trying to use web support but don't have the required dependencies installed.
Please install react-native-web@~0.19.6, react-dom@18.2.0, @expo/webpack-config@^19.0.0
```

## Solution

Added a new "For Expo projects with web support" section to `prompts.py` that instructs Claude to include web-specific dependencies when "web" is in the platforms array:

- `react-dom: 18.3.1` (required for web rendering)
- `react-native-web: ~0.19.12` (bridges React Native to web)
- `@expo/metro-runtime: ~4.0.0` (Expo web runtime)

Also includes configuration guidance for app.json and metro.config.js.

## Testing

✅ All 236 tests pass  
✅ All linting checks pass  
✅ Guidance properly integrated into prompts

## Impact

- Generated Expo projects with web support will include all required dependencies
- No more missing dependency errors when running web version
- Proper configuration guidance for web platform

## Related Issues

Fixes #30  
Builds on #28 (React versions) and #29 (Expo versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)