### PR TITLE
feat: implement context accumulation system (#38)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { ProjectForm } from './components/ProjectForm'
 import { GenerationProgress } from './components/GenerationProgress'
 import { CompletionScreen } from './components/CompletionScreen'
+import { SuggestionProvider } from './contexts/SuggestionContext'
 import type { ProjectConfig, GenerationResult } from './types'
 
 type AppState = 'form' | 'generating' | 'complete'
@@ -28,34 +29,36 @@ function App() {
   }
 
   return (
-    <div className="min-h-screen">
-      <header className="bg-white shadow-sm">
-        <div className="max-w-4xl mx-auto px-4 py-4">
-          <h1 className="text-2xl font-bold text-gray-900">SpecInit</h1>
-          <p className="text-sm text-gray-600">AI-Powered Project Generator</p>
-        </div>
-      </header>
+    <SuggestionProvider>
+      <div className="min-h-screen">
+        <header className="bg-white shadow-sm">
+          <div className="max-w-4xl mx-auto px-4 py-4">
+            <h1 className="text-2xl font-bold text-gray-900">SpecInit</h1>
+            <p className="text-sm text-gray-600">AI-Powered Project Generator</p>
+          </div>
+        </header>
 
-      <main className="max-w-4xl mx-auto px-4 py-8">
-        {state === 'form' && (
-          <ProjectForm onSubmit={handleFormSubmit} />
-        )}
+        <main className="max-w-4xl mx-auto px-4 py-8">
+          {state === 'form' && (
+            <ProjectForm onSubmit={handleFormSubmit} />
+          )}
 
-        {state === 'generating' && projectConfig && (
-          <GenerationProgress
-            config={projectConfig}
-            onComplete={handleGenerationComplete}
-          />
-        )}
+          {state === 'generating' && projectConfig && (
+            <GenerationProgress
+              config={projectConfig}
+              onComplete={handleGenerationComplete}
+            />
+          )}
 
-        {state === 'complete' && result && (
-          <CompletionScreen
-            result={result}
-            onNewProject={handleReset}
-          />
-        )}
-      </main>
-    </div>
+          {state === 'complete' && result && (
+            <CompletionScreen
+              result={result}
+              onNewProject={handleReset}
+            />
+          )}
+        </main>
+      </div>
+    </SuggestionProvider>
   )
 }
 

--- a/frontend/src/contexts/SuggestionContext.tsx
+++ b/frontend/src/contexts/SuggestionContext.tsx
@@ -1,0 +1,224 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, useCallback, useMemo } from 'react'
+
+// Types
+interface ProjectContext {
+  projectName?: string
+  projectDescription?: string
+  platforms?: string[]
+  userStory?: {
+    role?: string
+    action?: string
+    outcome?: string
+  }
+  features?: string[]
+  techStack?: {
+    frontend?: string[]
+    backend?: string[]
+    database?: string[]
+    tools?: string[]
+  }
+  aesthetics?: string[]
+  additionalContext?: string
+}
+
+interface SuggestionContextType {
+  // Accumulated form data
+  context: ProjectContext
+  updateContext: (field: string, value: unknown) => void
+
+  // Suggestion state
+  suggestionsEnabled: boolean
+  setSuggestionsEnabled: (enabled: boolean) => void
+
+  // Cost tracking
+  totalCost: number
+  addCost: (cost: number) => void
+
+  // Suggestion fetching
+  getSuggestions: (field: string, currentValue?: string) => Promise<string[]>
+  isLoading: boolean
+}
+
+interface SuggestionCache {
+  [key: string]: {
+    suggestions: string[]
+    timestamp: number
+  }
+}
+
+// Create context
+const SuggestionContext = createContext<SuggestionContextType | undefined>(undefined)
+
+// Cache TTL (5 minutes)
+const CACHE_TTL_MS = 5 * 60 * 1000
+const MAX_CACHE_SIZE = 20
+
+// Provider component
+export function SuggestionProvider({ children }: { children: React.ReactNode }) {
+  const [context, setContext] = useState<ProjectContext>({})
+  const [suggestionsEnabled, setSuggestionsEnabled] = useState(false)
+  const [totalCost, setTotalCost] = useState(0)
+  const [isLoading, setIsLoading] = useState(false)
+  const [suggestionCache, setSuggestionCache] = useState<SuggestionCache>({})
+
+  // Update context with debouncing handled by the caller
+  const updateContext = useCallback((field: string, value: unknown) => {
+    setContext((prev) => ({
+      ...prev,
+      [field]: value,
+    }))
+  }, [])
+
+  // Add cost to running total
+  const addCost = useCallback((cost: number) => {
+    setTotalCost((prev) => prev + cost)
+  }, [])
+
+  // Generate cache key from field and context
+  const getCacheKey = useCallback((field: string, ctx: ProjectContext): string => {
+    // Create normalized context (exclude undefined, sort keys)
+    const normalized: Record<string, unknown> = {}
+    Object.keys(ctx)
+      .sort()
+      .forEach((key) => {
+        const value = ctx[key as keyof ProjectContext]
+        if (value !== undefined) {
+          normalized[key] = value
+        }
+      })
+    return `${field}:${JSON.stringify(normalized)}`
+  }, [])
+
+  // Clean expired cache entries
+  const cleanCache = useCallback(() => {
+    const now = Date.now()
+    setSuggestionCache((prev) => {
+      const cleaned: SuggestionCache = {}
+      const entries = Object.entries(prev)
+
+      // Keep only non-expired entries
+      entries.forEach(([key, value]) => {
+        if (now - value.timestamp < CACHE_TTL_MS) {
+          cleaned[key] = value
+        }
+      })
+
+      // If still over max size, keep only most recent
+      if (Object.keys(cleaned).length > MAX_CACHE_SIZE) {
+        const sorted = Object.entries(cleaned).sort(
+          ([, a], [, b]) => b.timestamp - a.timestamp
+        )
+        const limited: SuggestionCache = {}
+        sorted.slice(0, MAX_CACHE_SIZE).forEach(([key, value]) => {
+          limited[key] = value
+        })
+        return limited
+      }
+
+      return cleaned
+    })
+  }, [])
+
+  // Fetch suggestions from API
+  const getSuggestions = useCallback(
+    async (field: string, currentValue: string = ''): Promise<string[]> => {
+      if (!suggestionsEnabled) {
+        return []
+      }
+
+      // Check cache first
+      const cacheKey = getCacheKey(field, context)
+      const cached = suggestionCache[cacheKey]
+      if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+        return cached.suggestions
+      }
+
+      setIsLoading(true)
+      try {
+        // Call backend API
+        const response = await fetch('/api/suggest', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            field,
+            context,
+            current_value: currentValue,
+            count: 5,
+          }),
+        })
+
+        if (!response.ok) {
+          const error = await response.json()
+          throw new Error(error.detail || 'Failed to fetch suggestions')
+        }
+
+        const data = await response.json()
+        const suggestions = data.suggestions || []
+
+        // Update cost
+        if (data.cost) {
+          addCost(data.cost)
+        }
+
+        // Cache the result
+        setSuggestionCache((prev) => ({
+          ...prev,
+          [cacheKey]: {
+            suggestions,
+            timestamp: Date.now(),
+          },
+        }))
+
+        // Clean cache periodically
+        cleanCache()
+
+        return suggestions
+      } catch (error) {
+        console.error('Error fetching suggestions:', error)
+        // Return empty array on error, don't throw
+        return []
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [suggestionsEnabled, context, suggestionCache, getCacheKey, addCost, cleanCache]
+  )
+
+  // Provide context value
+  const value = useMemo(
+    () => ({
+      context,
+      updateContext,
+      suggestionsEnabled,
+      setSuggestionsEnabled,
+      totalCost,
+      addCost,
+      getSuggestions,
+      isLoading,
+    }),
+    [
+      context,
+      updateContext,
+      suggestionsEnabled,
+      setSuggestionsEnabled,
+      totalCost,
+      addCost,
+      getSuggestions,
+      isLoading,
+    ]
+  )
+
+  return <SuggestionContext.Provider value={value}>{children}</SuggestionContext.Provider>
+}
+
+// Hook to use suggestion context
+export function useSuggestionContext() {
+  const context = useContext(SuggestionContext)
+  if (context === undefined) {
+    throw new Error('useSuggestionContext must be used within a SuggestionProvider')
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
Implements the React Context Provider for managing suggestion state across the entire app (Issue #38).

## Changes
**New Module**: `frontend/src/contexts/SuggestionContext.tsx`
- Complete Context Provider with state management
- Hook: `useSuggestionContext()` for component access

## Features

### Context Accumulation
- Tracks all form data: projectName, projectDescription, platforms, userStory, features, techStack, aesthetics
- `updateContext(field, value)` accumulates data as user progresses
- Normalized serialization for consistent cache keys

### Suggestion Fetching
- `getSuggestions(field, currentValue?)` fetches from `/api/suggest`
- Passes full accumulated context to API
- Returns suggestions array or empty array on error

### Intelligent Caching
- Cache key: Hash of `field + normalized context`
- TTL: 5 minutes
- Max entries: 20 (auto-cleanup on size/expiry)
- Prevents redundant API calls for same context

### Cost Tracking
- `totalCost` accumulates from each API response
- `addCost(cost)` updates running total
- Real-time cost display ready

### Loading & Error Handling
- `isLoading` boolean for UI feedback
- Graceful error handling (logs error, returns `[]`)
- Non-blocking failures

## Provider Integration
- App wrapped in `<SuggestionProvider>`
- Global state accessible via `useSuggestionContext()`
- Memory-only (privacy-conscious, no persistence)

## Technical Details
- Uses React Context API (not Redux/external library)
- `useMemo` for derived values
- `useCallback` for stable function references
- Efficient cache cleanup strategy
- TypeScript strict mode compliant

## Test Coverage
- All 274 Python tests passing, 90.16% coverage
- TypeScript compilation passing
- ESLint passing (with react-refresh exception)

## Next Steps
This enables immediate implementation of:
- #39: User story suggestions
- #40: Feature suggestions  
- #41: Tech stack suggestions

Components can now call `getSuggestions()` with full accumulated context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)